### PR TITLE
Allow template to be specified in options

### DIFF
--- a/bootstrap-modal-builder.js
+++ b/bootstrap-modal-builder.js
@@ -59,8 +59,8 @@
    * ======================= */
 
   $.modal = function (options) {
-    var modal = $($.modal.defaults.template)
-      , options = $.extend({}, $.modal.defaults, options);
+  	var options = $.extend({}, $.modal.defaults, options),
+      modal = $(options.template);
     modal.find('.modal-header')[options.header ? 'show' : 'hide']().children('h3').text(options.title);
     modal.find('.modal-body').html(options.content);
     modal.find('.modal-footer')[options.footer ? 'show' : 'hide']();


### PR DESCRIPTION
As we extend model.defaults after the modal element is created, the
default template is used even when a different template is specified in
the options object.